### PR TITLE
Fix Lua error in wishlist delete dialog

### DIFF
--- a/UI/MainWindow.lua
+++ b/UI/MainWindow.lua
@@ -482,7 +482,7 @@ StaticPopupDialogs["LOOTWISHLIST_DELETE_WISHLIST"] = {
     OnShow = function(self)
         -- Get current name at show time
         local currentName = ns:GetActiveWishlistName()
-        self.text:SetFormattedText("Delete wishlist \"%s\"?\n\nThis cannot be undone.", currentName)
+        self.Text:SetFormattedText("Delete wishlist \"%s\"?\n\nThis cannot be undone.", currentName)
         self.data = currentName  -- Store for OnAccept
     end,
     OnAccept = function(self)


### PR DESCRIPTION
 Closes #1 
 
 Use self.Text (capital T) to access the StaticPopup FontString child instead of self.text. 